### PR TITLE
castor: use specific idProduct for usb paths

### DIFF
--- a/aosp_sgp521.mk
+++ b/aosp_sgp521.mk
@@ -77,4 +77,5 @@ PRODUCT_AAPT_PREBUILT_DPI := xhdpi hdpi
 PRODUCT_AAPT_PREF_CONFIG := xhdpi
 
 PRODUCT_PROPERTY_OVERRIDES += \
-    ro.sf.lcd_density=320
+    ro.sf.lcd_density=320 \
+    ro.usb.pid_suffix=1B1


### PR DESCRIPTION
from 23.0.1.A.0.167

Signed-off-by: David Viteri davidteri91@gmail.com
