### PR TITLE
castor: inherit dalvik definitions for tablets

### DIFF
--- a/aosp_sgp521_common.mk
+++ b/aosp_sgp521_common.mk
@@ -18,7 +18,7 @@ DEVICE_PACKAGE_OVERLAYS += \
 $(call inherit-product, $(SRC_TARGET_DIR)/product/aosp_base.mk)
 $(call inherit-product, device/sony/shinano/device.mk)
 $(call inherit-product, vendor/sony/castor/castor-vendor.mk)
-$(call inherit-product, frameworks/native/build/phone-xhdpi-2048-dalvik-heap.mk)
+$(call inherit-product, frameworks/native/build/tablet-10in-xhdpi-2048-dalvik-heap.mk)
 $(call inherit-product, hardware/broadcom/wlan/bcmdhd/config/config-bcm.mk)
 $(call inherit-product-if-exists, prebuilts/chromium/webview_prebuilt.mk)
 $(call inherit-product-if-exists, vendor/google/products/gms.mk)


### PR DESCRIPTION
Z2 tablet has 10.1 inc. display, inherit proper dalvik definitions https://android.googlesource.com/platform/frameworks/native/+/android-6.0.0_r1/build/tablet-10in-xhdpi-2048-dalvik-heap.mk

Signed-off-by: David Viteri davidteri91@gmail.com
