### PR TITLE
castor: Update NFC NXP HAL naming

### DIFF
--- a/aosp_sgp521.mk
+++ b/aosp_sgp521.mk
@@ -17,6 +17,10 @@ TARGET_KERNEL_CONFIG := aosp_shinano_castor_defconfig
 $(call inherit-product, $(SRC_TARGET_DIR)/product/telephony.mk)
 $(call inherit-product, device/sony/castor/aosp_sgp521_common.mk)
 
+# NFC config
+PRODUCT_PACKAGES += nfc_nci.castor
+ADDITIONAL_DEFAULT_PROPERTIES += ro.hardware.nfc_nci=castor
+
 PRODUCT_NAME := aosp_sgp521
 PRODUCT_DEVICE := castor
 PRODUCT_MODEL := Xperia Z2 Tablet (AOSP)


### PR DESCRIPTION
This patch just uses AOSP directives by updating NFC HAL name
using the device name and declares the additional property "ro.hardware.nfc_nci"
to default.prop. So it fixes hw_get_module process.

AOSP uses $(TARGET_DEVICE) as NFC HAL composition naming
as commented here:

https://android-review.googlesource.com/#/c/155054/

By: Thierry Strudel

TARGET_BOARD_PLATFORM is set to the SoC name of a product
and the NFC chip has no relation to it.
TARGET_DEVICE is the only variable fully defining the device
and so selecting an HW device appropriately.
Given it should be easy to update PRODUCT_PACKAGES of any legacy device

Signed-off-by: Humberto Borba humberos@gmail.com
